### PR TITLE
Change ExceptionCreator access modifier to internal

### DIFF
--- a/src/Exceptions/ExceptionCreator.cs
+++ b/src/Exceptions/ExceptionCreator.cs
@@ -1,6 +1,6 @@
 ﻿namespace Menso.Tools.Exceptions;
 
-public static class ExceptionCreator
+internal static class ExceptionCreator
 {
     public static Exception CreateException(ExceptionInformation exceptionInformation)
     {


### PR DESCRIPTION
ExceptionCreator class has been changed from public to internal, restricting its access to the within assembly it's defined in. This adjustment is made to prevent undesired accessibility outside the assembly and uphold encapsulation practices.