### PR TITLE
Update project properties in Menso.Tools.Exceptions.csproj

### DIFF
--- a/src/Exceptions/Menso.Tools.Exceptions.csproj
+++ b/src/Exceptions/Menso.Tools.Exceptions.csproj
@@ -4,16 +4,44 @@
         <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-
+    </PropertyGroup>
+    
+    <PropertyGroup>
         <PackageId>Menso.Tools.Exceptions</PackageId>
-        <Authors>Emerson Trindade (MensoDev)</Authors>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+<!--        <PackageIcon>Nuget.png</PackageIcon>-->
         <Company>Menso</Company>
+        <Authors>Emerson Trindade (MensoDev)</Authors>
+        <Copyright>Copyright 2022 MudBlazor</Copyright>
+        <PackageTags>C#, Csharp, Exception, Exception Launcher</PackageTags>
         <PackageDescription>...Exception Launcher...</PackageDescription>
         <RepositoryUrl>https://github.com/MensoDev/Tools</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
     </PropertyGroup>
+
+    <PropertyGroup>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <IsTrimmable>true</IsTrimmable>
+        <TrimMode>link</TrimMode>
+        <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    </PropertyGroup>
+
+<!--    <PropertyGroup>-->
+<!--        <GenerateDocumentationFile>true</GenerateDocumentationFile>-->
+<!--        <GeneratePackageOnBuild>False</GeneratePackageOnBuild>-->
+<!--        <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>-->
+<!--    </PropertyGroup>-->
+    
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
             <_Parameter1>$(MSBuildProjectName).Tests</_Parameter1>
         </AssemblyAttribute>
     </ItemGroup>
+    
 </Project>


### PR DESCRIPTION
Extended the structure of Menso.Tools.Exceptions.csproj by enriching the properties group. This update includes adding package license information, package tags, repository URL and type, enablement of trim analyzer, and configuration for embedding untracked sources and symbols. This amendment is intended to provide more metadata for NuGet package, improving indexing and visibility. Also, it envisages the compliance with certain open-source repository best practices.