### PR TITLE
Update project metadata and remove redundant code

### DIFF
--- a/src/Exceptions/Menso.Tools.Exceptions.csproj
+++ b/src/Exceptions/Menso.Tools.Exceptions.csproj
@@ -5,14 +5,13 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
-    
+
     <PropertyGroup>
         <PackageId>Menso.Tools.Exceptions</PackageId>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-<!--        <PackageIcon>Nuget.png</PackageIcon>-->
         <Company>Menso</Company>
         <Authors>Emerson Trindade (MensoDev)</Authors>
-        <Copyright>Copyright 2022 MudBlazor</Copyright>
+        <Copyright>Copyright 2023 Menso</Copyright>
         <PackageTags>C#, Csharp, Exception, Exception Launcher</PackageTags>
         <PackageDescription>...Exception Launcher...</PackageDescription>
         <RepositoryUrl>https://github.com/MensoDev/Tools</RepositoryUrl>
@@ -32,16 +31,10 @@
         <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     </PropertyGroup>
 
-<!--    <PropertyGroup>-->
-<!--        <GenerateDocumentationFile>true</GenerateDocumentationFile>-->
-<!--        <GeneratePackageOnBuild>False</GeneratePackageOnBuild>-->
-<!--        <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>-->
-<!--    </PropertyGroup>-->
-    
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
             <_Parameter1>$(MSBuildProjectName).Tests</_Parameter1>
         </AssemblyAttribute>
     </ItemGroup>
-    
+
 </Project>


### PR DESCRIPTION
This commit updates the copyright year and ownership in `Menso.Tools.Exceptions.csproj`. Furthermore, it removes commented-out properties that were not required, resulting in cleaner, more maintainable code. The changes are mainly cosmetic but align the code better with current practices.