### PR TITLE
Renamed BeNotNull to NotBeNull in Exception Handling

### DIFF
--- a/src/Exceptions/IWhen.cs
+++ b/src/Exceptions/IWhen.cs
@@ -5,7 +5,7 @@ public interface IWhen
     #region Generic types
 
     void BeNull<T>([NotNull] T? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
-    void BeNotNull<T>(T? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
+    void NotBeNull<T>(T? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
     void AreEqual<T>(T? expected, T? actual, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(actual))] string? paramName = null);
     void AreNotEqual<T>(T? notExpected, T? actual, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(actual))] string? paramName = null);
 

--- a/src/Exceptions/When_GenericType.cs
+++ b/src/Exceptions/When_GenericType.cs
@@ -10,7 +10,7 @@ internal partial class When
             ThrowException($"Argument '{paramName}' must not be null", message, paramName, innerException);
     }
 
-    public void BeNotNull<T>(T? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+    public void NotBeNull<T>(T? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
     {
         if (argument is not null)
             ThrowException($"Argument '{paramName}' must be null", message, paramName, innerException);

--- a/tests/Exceptions.Tests/WhenTests.cs
+++ b/tests/Exceptions.Tests/WhenTests.cs
@@ -54,13 +54,13 @@ public class WhenTests
     }
 
     [Fact]
-    public void IsNotNull_WhenArgumentIsNotNull_ThrowsException()
+    public void NotBeNull_WhenArgumentIsNotNull_ThrowsException()
     {
         // Arrange
         object argument = new();
 
         // Act
-        var execution = () => _when.BeNotNull(argument);
+        var execution = () => _when.NotBeNull(argument);
 
         // Assert
         execution
@@ -70,13 +70,13 @@ public class WhenTests
     }
 
     [Fact]
-    public void IsNotNull_WhenArgumentIsNotNull_ThrowsException_WithInnerException()
+    public void NotBeNull_WhenArgumentIsNotNull_ThrowsException_WithInnerException()
     {
         // Arrange
         object argument = new();
 
         // Act
-        var execution = () => _when.BeNotNull(argument, innerException: _innerException);
+        var execution = () => _when.NotBeNull(argument, innerException: _innerException);
 
         // Assert
         execution
@@ -87,13 +87,13 @@ public class WhenTests
     }
 
     [Fact]
-    public void IsNotNull_WhenArgumentIsNull_DoesNotThrowException()
+    public void NotBeNull_WhenArgumentIsNull_DoesNotThrowException()
     {
         // Arrange
         object? argument = null;
 
         // Act
-        var execution = () => _when.BeNotNull(argument);
+        var execution = () => _when.NotBeNull(argument);
 
         // Assert
         execution.Should().NotThrow();


### PR DESCRIPTION
The method name in the Exception Handling class and related tests has been changed from BeNotNull to NotBeNull to improve readability and better convey its purpose. This should alleviate potential confusions regarding the method's intended function.