### PR TITLE
🪛 (Exceptions) Refactor method names for better clarity | closes #13

### DIFF
--- a/src/Exceptions/IWhen.cs
+++ b/src/Exceptions/IWhen.cs
@@ -14,7 +14,7 @@ public interface IWhen
     #region String type
 
     void Empty(string argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
-    void EmptyOrNull([NotNull] string? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
+    void NullOrEmpty([NotNull] string? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
     void NullOrWhiteSpace([NotNull] string? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
 
     #endregion
@@ -22,14 +22,14 @@ public interface IWhen
     #region Enumerable type
 
     void Empty<T>(IEnumerable<T> argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
-    void EmptyOrNull<T>([NotNull] IEnumerable<T>? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
+    void NullOrEmpty<T>([NotNull] IEnumerable<T>? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
 
     #endregion
 
     #region Guid type
 
     void Empty(Guid argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
-    void EmptyOrNull([NotNull] Guid? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
+    void NullOrEmpty([NotNull] Guid? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
 
     #endregion
 

--- a/src/Exceptions/When_BooleanType.cs
+++ b/src/Exceptions/When_BooleanType.cs
@@ -16,7 +16,7 @@ internal partial class When
             ThrowException($"Argument '{paramName}' must be true", message, paramName, innerException);
     }
 
-    public void FalseOrNull([NotNull] bool? argument, string? message = null, Exception? innerException = null, string? paramName = null)
+    public void FalseOrNull([NotNull] bool? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
     {
         if (argument is false or null)
             ThrowException($"Argument '{paramName}' must be true", message, paramName, innerException);

--- a/src/Exceptions/When_EnumerableType.cs
+++ b/src/Exceptions/When_EnumerableType.cs
@@ -10,7 +10,7 @@ internal partial class When
             ThrowException($"Argument '{paramName}' must not be empty", message, paramName, innerException);
     }
 
-    public void EmptyOrNull<T>([NotNull] IEnumerable<T>? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+    public void NullOrEmpty<T>([NotNull] IEnumerable<T>? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
     {
         if (argument is null || argument.Any() is false)
             ThrowException($"Argument '{paramName}' must not be null or empty", message, paramName, innerException);

--- a/src/Exceptions/When_GuidType.cs
+++ b/src/Exceptions/When_GuidType.cs
@@ -10,7 +10,7 @@ internal partial class When
             ThrowException($"Argument '{paramName}' must not be empty", message, paramName, innerException);
     }
 
-    public void EmptyOrNull([NotNull] Guid? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+    public void NullOrEmpty([NotNull] Guid? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
     {
         if (argument is null || argument == Guid.Empty)
             ThrowException($"Argument '{paramName}' must not be null or empty", message, paramName, innerException);

--- a/src/Exceptions/When_StringType.cs
+++ b/src/Exceptions/When_StringType.cs
@@ -12,7 +12,7 @@ internal partial class When
             ThrowException($"Argument '{paramName}' must not be empty", message, paramName, innerException);
     }
 
-    public void EmptyOrNull([NotNull] string? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+    public void NullOrEmpty([NotNull] string? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
     {
         if (string.IsNullOrEmpty(argument))
             ThrowException($"Argument '{paramName}' must not be null or empty", message, paramName, innerException);

--- a/tests/Exceptions.Tests/WhenTests.cs
+++ b/tests/Exceptions.Tests/WhenTests.cs
@@ -231,13 +231,13 @@ public class WhenTests
     }
     
     [Fact]
-    public void EmptyOrNull_WhenStringArgumentIsEmpty_ThrowsException()
+    public void NullOrEmpty_WhenStringArgumentIsEmpty_ThrowsException()
     {
         // Arrange
         var argument = string.Empty;
 
         // Act
-        var execution = () => _when.EmptyOrNull(argument);
+        var execution = () => _when.NullOrEmpty(argument);
 
         // Assert
         execution
@@ -247,13 +247,13 @@ public class WhenTests
     }
     
     [Fact]
-    public void EmptyOrNull_WhenStringArgumentIsNull_ThrowsException()
+    public void NullOrEmpty_WhenStringArgumentIsNull_ThrowsException()
     {
         // Arrange
         string argument = null!;
 
         // Act
-        var execution = () => _when.EmptyOrNull(argument);
+        var execution = () => _when.NullOrEmpty(argument);
 
         // Assert
         execution
@@ -263,13 +263,13 @@ public class WhenTests
     }
 
     [Fact]
-    public void EmptyOrNull_WhenStringArgumentIsNotEmptyOrNull_DoesNotThrowException()
+    public void NullOrEmpty_WhenStringArgumentIsNotEmptyOrNull_DoesNotThrowException()
     {
         // Arrange
         const string argument = "not empty";
 
         // Act
-        var execution = () => _when.EmptyOrNull(argument);
+        var execution = () => _when.NullOrEmpty(argument);
 
         // Assert
         execution.Should().NotThrow();
@@ -354,13 +354,13 @@ public class WhenTests
     }
     
     [Fact]
-    public void EmptyOrNull_WhenEnumerableArgumentIsEmpty_ThrowsException()
+    public void NullOrEmpty_WhenEnumerableArgumentIsEmpty_ThrowsException()
     {
         // Arrange
         var argument = Enumerable.Empty<object>();
 
         // Act
-        var execution = () => _when.EmptyOrNull(argument);
+        var execution = () => _when.NullOrEmpty(argument);
 
         // Assert
         execution
@@ -370,13 +370,13 @@ public class WhenTests
     }
     
     [Fact]
-    public void EmptyOrNull_WhenEnumerableArgumentIsNull_ThrowsException()
+    public void NullOrEmpty_WhenEnumerableArgumentIsNull_ThrowsException()
     {
         // Arrange
         IEnumerable<object> argument = null!;
 
         // Act
-        var execution = () => _when.EmptyOrNull(argument);
+        var execution = () => _when.NullOrEmpty(argument);
 
         // Assert
         execution
@@ -386,13 +386,13 @@ public class WhenTests
     }
 
     [Fact]
-    public void EmptyOrNull_WhenEnumerableArgumentIsNotEmpty_DoesNotThrowException()
+    public void NullOrEmpty_WhenEnumerableArgumentIsNotEmpty_DoesNotThrowException()
     {
         // Arrange
         var argument = new[] { new object() };
 
         // Act
-        var execution = () => _when.EmptyOrNull(argument);
+        var execution = () => _when.NullOrEmpty(argument);
 
         // Assert
         execution.Should().NotThrow();
@@ -432,13 +432,13 @@ public class WhenTests
     }
     
     [Fact]
-    public void EmptyOrNull_WhenGuidArgumentIsEmpty_ThrowsException()
+    public void NullOrEmpty_WhenGuidArgumentIsEmpty_ThrowsException()
     {
         // Arrange
         var argument = Guid.Empty;
 
         // Act
-        var execution = () => _when.EmptyOrNull(argument);
+        var execution = () => _when.NullOrEmpty(argument);
 
         // Assert
         execution
@@ -448,13 +448,13 @@ public class WhenTests
     }
     
     [Fact]
-    public void EmptyOrNull_WhenGuidArgumentIsNull_ThrowsException()
+    public void NullOrEmpty_WhenGuidArgumentIsNull_ThrowsException()
     {
         // Arrange
         Guid? argument = null;
 
         // Act
-        var execution = () => _when.EmptyOrNull(argument);
+        var execution = () => _when.NullOrEmpty(argument);
 
         // Assert
         execution
@@ -470,7 +470,7 @@ public class WhenTests
         var argument = Guid.NewGuid();
 
         // Act
-        var execution = () => _when.EmptyOrNull(argument);
+        var execution = () => _when.NullOrEmpty(argument);
 
         // Assert
         execution.Should().NotThrow<ArgumentException>();


### PR DESCRIPTION
The method names including 'EmptyOrNull' have been refactored to 'NullOrEmpty'. This change was made to improve clarity and code readability. The name change makes it more apparent that the checked value should not be neither null nor empty. The change was propagated throughout the codebase to keep the naming convention consistent.

closes #13