### PR TITLE
🧹 (Exceptions) Split IWhen interface into multiple specific interfaces | closes #15

### DIFF
--- a/src/Exceptions/IWhen.cs
+++ b/src/Exceptions/IWhen.cs
@@ -1,6 +1,6 @@
 ﻿namespace Menso.Tools.Exceptions;
 
-public interface IWhen
+public interface IWhen : IWhenString, IWhenGuid, IWhenBoolean, IWhenEnumerable
 {
     #region Generic types
 
@@ -10,35 +10,5 @@ public interface IWhen
     void NotEqual<T>(T? notExpected, T? actual, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(actual))] string? paramName = null);
 
     #endregion
-
-    #region String type
-
-    void Empty(string argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
-    void NullOrEmpty([NotNull] string? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
-    void NullOrWhiteSpace([NotNull] string? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
-
-    #endregion
-
-    #region Enumerable type
-
-    void Empty<T>(IEnumerable<T> argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
-    void NullOrEmpty<T>([NotNull] IEnumerable<T>? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
-
-    #endregion
-
-    #region Guid type
-
-    void Empty(Guid argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
-    void NullOrEmpty([NotNull] Guid? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
-
-    #endregion
-
-    #region Boolean type
-
-    void True(bool argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
-    void False(bool argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
-    void FalseOrNull([NotNull] bool? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
-
-    #endregion
-
+    
 }

--- a/src/Exceptions/IWhenBoolean.cs
+++ b/src/Exceptions/IWhenBoolean.cs
@@ -1,0 +1,8 @@
+﻿namespace Menso.Tools.Exceptions;
+
+public interface IWhenBoolean
+{
+    void True(bool argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
+    void False(bool argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
+    void FalseOrNull([NotNull] bool? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
+}

--- a/src/Exceptions/IWhenEnumerable.cs
+++ b/src/Exceptions/IWhenEnumerable.cs
@@ -1,0 +1,7 @@
+﻿namespace Menso.Tools.Exceptions;
+
+public interface IWhenEnumerable
+{
+    void Empty<T>(IEnumerable<T> argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
+    void NullOrEmpty<T>([NotNull] IEnumerable<T>? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
+}

--- a/src/Exceptions/IWhenGuid.cs
+++ b/src/Exceptions/IWhenGuid.cs
@@ -1,0 +1,7 @@
+﻿namespace Menso.Tools.Exceptions;
+
+public interface IWhenGuid
+{
+    void Empty(Guid argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
+    void NullOrEmpty([NotNull] Guid? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
+}

--- a/src/Exceptions/IWhenString.cs
+++ b/src/Exceptions/IWhenString.cs
@@ -1,0 +1,8 @@
+﻿namespace Menso.Tools.Exceptions;
+
+public interface IWhenString
+{
+    void Empty(string argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
+    void NullOrEmpty([NotNull] string? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
+    void NullOrWhiteSpace([NotNull] string? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
+}


### PR DESCRIPTION
The IWhen interface was getting quite large and was dealing with a wide variety of cases, including Strings, Guids, Booleans, and Enumerables. To make it more manageable and follow the Single Responsibility Principle, we have decided to split it into multiple specific interfaces. It will make the code more readable, maintainable and easier to work with in the future. Now, the IWhen interface simply integrates all these smaller interfaces.

closes #15