### PR TITLE
🐞 (Exceptions) Renamed method 'FalseOrNull' to 'NullOrFalse' | closes #17

### DIFF
--- a/src/Exceptions/IWhenBoolean.cs
+++ b/src/Exceptions/IWhenBoolean.cs
@@ -4,5 +4,5 @@ public interface IWhenBoolean
 {
     void True(bool argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
     void False(bool argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
-    void FalseOrNull([NotNull] bool? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
+    void NullOrFalse([NotNull] bool? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null);
 }

--- a/src/Exceptions/When_BooleanType.cs
+++ b/src/Exceptions/When_BooleanType.cs
@@ -16,7 +16,7 @@ internal partial class When
             ThrowException($"Argument '{paramName}' must be true", message, paramName, innerException);
     }
 
-    public void FalseOrNull([NotNull] bool? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+    public void NullOrFalse([NotNull] bool? argument, string? message = null, Exception? innerException = null, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
     {
         if (argument is false or null)
             ThrowException($"Argument '{paramName}' must be true", message, paramName, innerException);

--- a/tests/Exceptions.Tests/WhenTests.cs
+++ b/tests/Exceptions.Tests/WhenTests.cs
@@ -539,13 +539,13 @@ public class WhenTests
     }
     
     [Fact]
-    public void FalseOrNull_WhenBooleanArgumentIsFalse_ThrowsException()
+    public void NullOrFalse_WhenBooleanArgumentIsFalse_ThrowsException()
     {
         // Arrange
         const bool argument = false;
 
         // Act
-        var execution = () => _when.FalseOrNull(argument);
+        var execution = () => _when.NullOrFalse(argument);
 
         // Assert
         execution
@@ -555,13 +555,13 @@ public class WhenTests
     }
     
     [Fact]
-    public void FalseOrNull_WhenBooleanArgumentIsNull_ThrowsException()
+    public void NullOrFalse_WhenBooleanArgumentIsNull_ThrowsException()
     {
         // Arrange
         bool? argument = null!;
 
         // Act
-        var execution = () => _when.FalseOrNull(argument);
+        var execution = () => _when.NullOrFalse(argument);
 
         // Assert
         execution
@@ -571,13 +571,13 @@ public class WhenTests
     }
     
     [Fact]
-    public void FalseOrNull_WhenBooleanArgumentIsTrue_DoesNotThrowException()
+    public void NullOrFalse_WhenBooleanArgumentIsTrue_DoesNotThrowException()
     {
         // Arrange
         const bool argument = true;
 
         // Act
-        var execution = () => _when.FalseOrNull(argument);
+        var execution = () => _when.NullOrFalse(argument);
 
         // Assert
         execution.Should().NotThrow<ArgumentException>();


### PR DESCRIPTION
closes #17

This change was made to improve the readability and clarity of the code. The method name 'NullOrFalse' is more intuitive and aligns better with its actual functionality, as it checks if the argument is null or false. This way, other developers can understand the code more easily without having to dig into its implementation.