### PR TITLE
Add Codecov to GitHub Actions workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,4 +27,9 @@ jobs:
         id: trx-parser
         with:
           TRX_PATH: ${{ github.workspace }}/TestResults #This should be the path to your TRX files
-          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}          
+          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This commit adds a new step in our GitHub Actions workflow. We now upload our test coverage reports to Codecov. This change aims to enhance our test reporting by integrating Codecov's coverage data with our existing test reports. This will, in turn, make it easier for us to track and improve our test coverage over time.