### PR TITLE
Update target frameworks for projects

### DIFF
--- a/src/Exceptions/Menso.Tools.Exceptions.csproj
+++ b/src/Exceptions/Menso.Tools.Exceptions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/Scrambler/Menso.Tools.Scrambler.csproj
+++ b/src/Scrambler/Menso.Tools.Scrambler.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/tests/Exceptions.Tests/Menso.Tools.Exceptions.Tests.csproj
+++ b/tests/Exceptions.Tests/Menso.Tools.Exceptions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/tests/Scrambler.Tests/Menso.Tools.Scrambler.Tests.csproj
+++ b/tests/Scrambler.Tests/Menso.Tools.Scrambler.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 


### PR DESCRIPTION
Target frameworks for the Exception, Scrambler, and their respective test projects have been updated. The Exception and Scrambler now target both .NET versions 7.0 and 8.0, and their test projects have been updated to target .NET version 8.0.